### PR TITLE
Discount not showing when discount_amount2 set and items added to cart individually

### DIFF
--- a/src/minicart.js
+++ b/src/minicart.js
@@ -809,7 +809,6 @@ PAYPAL.apps = PAYPAL.apps || {};
 			return true;
 		};
 
-
 		/**
 		 * Adds a product to the cart
 		 *
@@ -1140,7 +1139,7 @@ PAYPAL.apps = PAYPAL.apps || {};
 
 			// Discount
 			discount = this.getDiscount();
-
+			
 			if (discount) {
 				this.discountInput.type = 'hidden';
 				this.discountInput.name = 'discount_amount_' + position;
@@ -1268,7 +1267,14 @@ PAYPAL.apps = PAYPAL.apps || {};
 
 				if ((discount = this.getDiscount())) {
 					this.discountInput.value = discount;
-
+					/**
+					 * Append the discount node if it doesn't already exist
+					 *
+					 * @author Ethan Schroeder <ethan.schroeder@gmail.com>
+					 */
+					if(!this.discountNode.innerHTML) {
+						this.metaNode.appendChild(this.discountNode);
+					}
 					this.discountNode.innerHTML  = '<br />';
 					this.discountNode.innerHTML += config.strings.discount || 'Discount: ';
 					this.discountNode.innerHTML += $.util.formatCurrency(discount, this.settings.currency_code);


### PR DESCRIPTION
Discount node was conditionally added if there was an initial discount.
 If a product is configured to have a discount after quantity of one,
this discount node never gets created.  Detect if it exists, if not,
add it before changing the innerHTML.

Now, if a user adds individual items to their cart one at a time, after the first one is added, the discount amount shows for additional item discounts.  Before, a user would have to add 2 or more of the items to their cart off the bat to get the discount to appear.
