### PR TITLE
Made minicart display in document.body by default.

### DIFF
--- a/src/minicart.js
+++ b/src/minicart.js
@@ -312,6 +312,8 @@ PAYPAL.apps = PAYPAL.apps || {};
 				}
 
 				parent = (typeof config.parent === 'string') ? document.getElementById(config.parent) : config.parent;
+				if (parent == null)
+					parent = document.body;
 				parent.appendChild(UI.wrapper);
 			};
 


### PR DESCRIPTION
/README.md specifies document.body as default, but this was not occuring.
